### PR TITLE
Add netcat to the docker-compose file

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,6 +66,8 @@ services:
       - 9798:9798  # <-- ¡CAMBIO AQUÍ! Mapea el puerto 9798 del contenedor al 9696 del host
     image: ghcr.io/miguelndecarvalho/speedtest-exporter
     restart: always
+    init: true
+    entrypoint: ["/bin/sh", "-c", "apk add --no-cache netcat-openbsd && speedtest-exporter"]
     networks:
       - back-tier
     healthcheck:


### PR DESCRIPTION
Se agrega netcat al stack para que pase el health chack del speedtest